### PR TITLE
Add tar-fs and streaming-format to `package.json` as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "gunzip-maybe": "^1.0.2",
     "minimist": "^1.1.0",
     "read": "^1.0.5",
-    "request": "^2.40.0"
+    "request": "^2.40.0",
+    "streaming-format": "^1.0.0",
+    "tar-fs": "^0.5.0"
   },
   "devDependencies": {},
   "bin": {


### PR DESCRIPTION
These two modules are `require()`d but aren't listed as dependencies.
